### PR TITLE
Item carousels

### DIFF
--- a/index.html
+++ b/index.html
@@ -25,6 +25,12 @@
               <img class="item" src="./assets/spacehelmet.png">
             </span>
           </div>
+          <div class="slide-links">
+            <a class="slide-link" href="#tophat">1</a>
+            <a class="slide-link" href="#sunhat">2</a>
+            <a class="slide-link" href="#crown">3</a>
+            <a class="slide-link" href="#spacehelmet">4</a>
+          </div>
         </div>
         <div class="slides-container">
           <h3 class="sub-title">Clothes</h3>
@@ -35,6 +41,10 @@
             <span id="vest" class="item-slide">
               <img class="item" src="./assets/vest.png">
             </span>
+          </div>
+          <div class="slide-links">
+            <a class="slide-link" href="#dress">1</a>
+            <a class="slide-link" href="#vest">2</a>
           </div>
         </div>
         <div class="slides-container">
@@ -53,6 +63,12 @@
               <img class="item" src="./assets/hairbow.png">
             </span>
           </div>
+          <div class="slide-links">
+            <a class="slide-link" href="#necklace">1</a>
+            <a class="slide-link" href="#bowtie">2</a>
+            <a class="slide-link" href="#sunglasses">3</a>
+            <a class="slide-link" href="#hairbow">4</a>
+          </div>
         </div>
         <div class="slides-container">
           <h3 class="sub-title">Backgrounds</h3>
@@ -69,6 +85,12 @@
             <span id="hearts" class="item-slide">
               <img class="item" src="./assets/hearts.png">
             </span>
+          </div>
+          <div class="slide-links">
+            <a class="slide-link" href="#park">1</a>
+            <a class="slide-link" href="#beach">2</a>
+            <a class="slide-link" href="#outerspace">3</a>
+            <a class="slide-link" href="#hearts">4</a>
           </div>
         </div>
       </section>

--- a/index.html
+++ b/index.html
@@ -8,45 +8,55 @@
       <h1>Build-A-Bear</h1>
     </header>
     <main>
-      <section>
-        <article>
-          <h3>Hats</h3>
-          <div>
-            <button>Top Hat</button>
-            <button>Sun Hat</button>
-            <button>Bow</button>
-            <button>Crown</button>
+      <section class="items-column">
+        <div class="slides-container">
+          <h3 class="sub-title">Hats</h3>
+          <div class="slides">
+            <span class="item-slide">
+            </span>
+            <span class="item-slide">
+            </span>
+            <span class="item-slide">
+            </span>
+            <span class="item-slide">
+            </span>
           </div>
-        </article>
-        <article>
-          <h3>Clothes</h3>
-          <div>
-            <button>T-Shirt</button>
-            <button>Dress</button>
-            <button>Tuxedo</button>
+        </div>
+        <div class="slides-container">
+          <h3 class="sub-title">Clothes</h3>
+          <div class="clothes slides">
+            <span class="item-slide">
+            </span>
+            <span class="item-slide">
+            </span>
           </div>
-        </article>
-        <article>
-          <h3>Accessories</h3>
-          <div>
-            <button>Necklace</button>
-            <button>Bow Tie</button>
-            <button>Watch</button>
-            <button>Monocle</button>
-            <button>Earrings</button>
+        </div>
+        <div class="slides-container">
+          <h3 class="sub-title">Accessories</h3>
+          <div class="slides">
+            <span class="item-slide">
+            </span>
+            <span class="item-slide">
+            </span>
+            <span class="item-slide">
+            </span>
+            <span class="item-slide">
+            </span>
           </div>
-        </article>
-        <article>
-          <h3>Backgrounds</h3>
-          <div>
-            <button>Blue</button>
-            <button>Park</button>
-            <button>Beach</button>
-            <button>Space</button>
-            <button>Yellow</button>
-            <button>Hearts</button>
+        </div>
+        <div class="slides-container">
+          <h3 class="sub-title">Backgrounds</h3>
+          <div class="slides">
+            <span class="item-slide">
+            </span>
+            <span class="item-slide">
+            </span>
+            <span class="item-slide">
+            </span>
+            <span class="item-slide">
+            </span>
           </div>
-        </article>
+        </div>
       </section>
       <section>
         <div>

--- a/index.html
+++ b/index.html
@@ -12,16 +12,16 @@
         <div class="slides-container">
           <h3 class="sub-title">Hats</h3>
           <div class="slides">
-            <span class="item-slide">
+            <span id="tophat" class="item-slide">
               <img class="item" src="./assets/tophat.png">
             </span>
-            <span class="item-slide">
+            <span id="sunhat" class="item-slide">
               <img class="item" src="./assets/sunhat.png">
             </span>
-            <span class="item-slide">
+            <span id="crown" class="item-slide">
               <img class="item" src="./assets/crown.png">
             </span>
-            <span class="item-slide">
+            <span id="spacehelmet" class="item-slide">
               <img class="item" src="./assets/spacehelmet.png">
             </span>
           </div>
@@ -29,10 +29,10 @@
         <div class="slides-container">
           <h3 class="sub-title">Clothes</h3>
           <div class="clothes slides">
-            <span class="item-slide">
+            <span id="dress" class="item-slide">
               <img class="item" src="./assets/dress.png">
             </span>
-            <span class="item-slide">
+            <span id="vest" class="item-slide">
               <img class="item" src="./assets/vest.png">
             </span>
           </div>
@@ -40,16 +40,16 @@
         <div class="slides-container">
           <h3 class="sub-title">Accessories</h3>
           <div class="slides">
-            <span class="item-slide">
+            <span id="necklace" class="item-slide">
               <img class="item" src="./assets/necklace.png">
             </span>
-            <span class="item-slide">
+            <span id="bowtie" class="item-slide">
               <img class="item" src="./assets/bowtie.png">
             </span>
-            <span class="item-slide">
+            <span id="sunglasses" class="item-slide">
               <img class="item" src="./assets/sunglasses.png">
             </span>
-            <span class="item-slide">
+            <span id="hairbow" class="item-slide">
               <img class="item" src="./assets/hairbow.png">
             </span>
           </div>
@@ -57,16 +57,16 @@
         <div class="slides-container">
           <h3 class="sub-title">Backgrounds</h3>
           <div class="slides">
-            <span class="item-slide">
+            <span id="park" class="item-slide">
               <img class="item" src="./assets/park.png">
             </span>
-            <span class="item-slide">
+            <span id="beach" class="item-slide">
               <img class="item" src="./assets/beach.png">
             </span>
-            <span class="item-slide">
+            <span id="outerspace" class="item-slide">
               <img class="item" src="./assets/outerspace.png">
             </span>
-            <span class="item-slide">
+            <span id="hearts" class="item-slide">
               <img class="item" src="./assets/hearts.png">
             </span>
           </div>

--- a/index.html
+++ b/index.html
@@ -13,12 +13,16 @@
           <h3 class="sub-title">Hats</h3>
           <div class="slides">
             <span class="item-slide">
+              <img class="item" src="./assets/tophat.png">
             </span>
             <span class="item-slide">
+              <img class="item" src="./assets/sunhat.png">
             </span>
             <span class="item-slide">
+              <img class="item" src="./assets/crown.png">
             </span>
             <span class="item-slide">
+              <img class="item" src="./assets/spacehelmet.png">
             </span>
           </div>
         </div>
@@ -26,8 +30,10 @@
           <h3 class="sub-title">Clothes</h3>
           <div class="clothes slides">
             <span class="item-slide">
+              <img class="item" src="./assets/dress.png">
             </span>
             <span class="item-slide">
+              <img class="item" src="./assets/vest.png">
             </span>
           </div>
         </div>
@@ -35,12 +41,16 @@
           <h3 class="sub-title">Accessories</h3>
           <div class="slides">
             <span class="item-slide">
+              <img class="item" src="./assets/necklace.png">
             </span>
             <span class="item-slide">
+              <img class="item" src="./assets/bowtie.png">
             </span>
             <span class="item-slide">
+              <img class="item" src="./assets/sunglasses.png">
             </span>
             <span class="item-slide">
+              <img class="item" src="./assets/hairbow.png">
             </span>
           </div>
         </div>
@@ -48,12 +58,16 @@
           <h3 class="sub-title">Backgrounds</h3>
           <div class="slides">
             <span class="item-slide">
+              <img class="item" src="./assets/park.png">
             </span>
             <span class="item-slide">
+              <img class="item" src="./assets/beach.png">
             </span>
             <span class="item-slide">
+              <img class="item" src="./assets/outerspace.png">
             </span>
             <span class="item-slide">
+              <img class="item" src="./assets/hearts.png">
             </span>
           </div>
         </div>

--- a/styles.css
+++ b/styles.css
@@ -29,6 +29,11 @@ header {
   align-items: center;
 }
 
+.sub-title {
+  color: white;
+  padding-bottom: 10px;
+}
+
 /* Left Section */
 .items-column {
   width: 30%;
@@ -69,6 +74,11 @@ header {
   height: 90px;
   position: relative;
   bottom: 30px;
+}
+
+.slide-links {
+  text-align: center;
+  display: inline-block;
 }
 
 .slide-link {

--- a/styles.css
+++ b/styles.css
@@ -30,6 +30,18 @@ header {
 }
 
 /* Left Section */
+.items-column {
+  width: 30%;
+  align-items: flex-start;
+}
+
+.slides {
+  height: 70px;
+  display: flex;
+  overflow-x: auto;
+  scroll-behavior: smooth;
+  scroll-snap-type: x mandatory;
+}
 
 .slides-container {
   width: 100%;

--- a/styles.css
+++ b/styles.css
@@ -60,6 +60,17 @@ header {
   scroll-snap-align: center;
 }
 
+.item {
+  height: 50px;
+  display: inline-block;
+}
+
+.clothes span img {
+  height: 90px;
+  position: relative;
+  bottom: 30px;
+}
+
 .slide-link {
   text-decoration: none;
   background-color: #DD4F40;

--- a/styles.css
+++ b/styles.css
@@ -30,9 +30,15 @@ header {
 }
 
 /* Left Section */
-article {
-  align-items: flex-start;
+
+.slides-container {
   width: 100%;
+  display: inline;
+  background-color: #487AB9;
+  border-radius: 10px;
+  margin: 5px;
+  padding: 10px;
+  text-align: center;
 }
 
 /* Middle Section */

--- a/styles.css
+++ b/styles.css
@@ -41,6 +41,13 @@ header {
   text-align: center;
 }
 
+.item-slide {
+  width: 100%;
+  flex-shrink: 0;
+  overflow: hidden;
+  scroll-snap-align: center;
+}
+
 /* Middle Section */
 
 /* Right Section */

--- a/styles.css
+++ b/styles.css
@@ -60,6 +60,14 @@ header {
   scroll-snap-align: center;
 }
 
+.slide-link {
+  text-decoration: none;
+  background-color: #DD4F40;
+  color: white;
+  border-radius: 100%;
+  padding: 3px 8px;
+}
+
 /* Middle Section */
 
 /* Right Section */

--- a/styles.css
+++ b/styles.css
@@ -37,7 +37,7 @@ header {
 /* Left Section */
 .items-column {
   width: 30%;
-  align-items: flex-start;
+  align-items: center;
 }
 
 .slides {
@@ -49,7 +49,7 @@ header {
 }
 
 .slides-container {
-  width: 100%;
+  width: 300px;
   display: inline;
   background-color: #487AB9;
   border-radius: 10px;
@@ -59,7 +59,7 @@ header {
 }
 
 .item-slide {
-  width: 100%;
+  width: 300px;
   flex-shrink: 0;
   overflow: hidden;
   scroll-snap-align: center;


### PR DESCRIPTION
This pull request:
* Adds the prototype for item carousels rather than buttons
* Adds basic styles for slides, links, and text within those carousels
* Attempts to make the right column fluid

Note: If the viewing window is expanded while not on the first slide in an item carousel, the slide is not centered within the column until after another scroll. This causes the item to be off center and potentially show another item in the side. (Removed percentages and used fixed width for this reason)